### PR TITLE
Fixed FastClick + HTTPs

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,8 +55,19 @@ app.use(flash()); // use connect-flash for flash messages stored in session
 app.use(function (req, res, next) {
 	res.locals.user = req.user;
 	res.locals.env = process.env.NODE_ENV || 'dev';
-	next();
+	return next();
 });
+
+// Force https
+if (process.env.NODE_ENV == 'production') {
+	app.use(function (req, res, next) {
+		if (req.headers['x-forwarded-proto'] !== 'https') {
+			return res.redirect(['https://', req.get('Host'), req.url].join(''));
+		}
+
+		return next();
+	});
+}
 
 mongoose.connect(process.env.DATABASE_URL);
 mongoose.connection.on('error', function (err) {

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -12,7 +12,7 @@ $(function () {
 		return $('div#dashboardTable table');
 	}
 
-	if (FastClick) {
+	if ('FastClick' in window) {
 		FastClick.attach(document.body);
 	}
 

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -12,7 +12,9 @@ $(function () {
 		return $('div#dashboardTable table');
 	}
 
-	FastClick.attach(document.body);
+	if (FastClick) {
+		FastClick.attach(document.body);
+	}
 
 	// Track what has been toggled in the search filters
 	var searchOptions = {


### PR DESCRIPTION
- Some ad blockers appear to block FastClick.js, so I added a check to see if it is available.
- Heroku gives SSL support for it's own domains, but it doesn't automatically upgrade to HTTP to HTTPs. Our app will now automatically redirect users to an HTTPs connection.
