### PR TITLE
Added Assignment Feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,12 @@ app.use(flash()); // use connect-flash for flash messages stored in session
 
 // Pass the access level to our Jade templates
 app.use(function (req, res, next) {
-	res.locals.user = req.user;
+	var u = req.user;
+	if (u) {
+		delete u.hash;
+	}
+
+	res.locals.user = u;
 	res.locals.env = process.env.NODE_ENV || 'dev';
 	return next();
 });

--- a/build_scripts/buildRequestBase.js
+++ b/build_scripts/buildRequestBase.js
@@ -72,7 +72,7 @@ function generateLeg() {
 	};
 }
 
-function generateRequest(user) {
+function generateRequest(user, staff) {
 	var isPending = randBool(0.3);
 	var isApproved = (isPending ? undefined : randBool(0.7));
 	var legs = [];
@@ -82,6 +82,7 @@ function generateRequest(user) {
 
 	return new Request({
 		userId: user._id,
+		staffId: staff._id,
 		status: {
 			isPending: isPending,
 			isApproved: isApproved,
@@ -117,15 +118,26 @@ function saveAll(objects, cb) {
 
 console.log(sprintf('Generating %d requests...', REQUESTS_TO_GENERATE));
 
-User.find({ access: Access.VOLUNTEER }, function (err, users) {
+User.find({  }, function (err, users) {
 	if (err) {
 		console.error(err);
 	}
 
+	var volunteers = [];
+	var staff = [];
+	for (var i = 0; i < users.length; i++) {
+		if (users[i].access == Access.VOLUNTEER) {
+			volunteers.push(users[i]);
+		} else {
+			staff.push(users[i]);
+		}
+	}
+
 	var requests = [];
 	for (var i = 0; i < REQUESTS_TO_GENERATE; i++) {
-		var randUser = users[randIndex(users.length)];
-		requests.push(generateRequest(randUser));
+		var randVolunteer = users[randIndex(volunteers.length)];
+		var randStaff = staff[randIndex(staff.length)];
+		requests.push(generateRequest(randVolunteer, randStaff));
 	}
 
 	console.log(sprintf('About to save %d requests.', requests.length));

--- a/config/passport.js
+++ b/config/passport.js
@@ -25,7 +25,7 @@ module.exports = function (passport) {
 
 	// used to deserialize the user
 	passport.deserializeUser(function (id, done) {
-		User.findById(id, function (err, user) {
+		User.findById(id).lean().exec(function (err, user) {
 			done(err, user);
 		});
 	});

--- a/models/request.js
+++ b/models/request.js
@@ -5,7 +5,8 @@ var mongoose = require('mongoose');
 var DateOnly = require('mongoose-dateonly')(mongoose);
 
 var requestSchema = mongoose.Schema({
-	userId: mongoose.Schema.Types.ObjectId,
+	userId: { type: mongoose.Schema.Types.ObjectId, required: true, },
+	staffId: { type: mongoose.Schema.Types.ObjectId, required: true, },
 	status: {
 		isPending: Boolean,
 		isApproved: Boolean,

--- a/public/css/submission.css
+++ b/public/css/submission.css
@@ -20,3 +20,6 @@
 #htmlwrapper .checkbox {
   display: table;
   margin: 10px auto; }
+
+#htmlwrapper #request-submit {
+  margin-top: 10px; }

--- a/public/js/submission.js
+++ b/public/js/submission.js
@@ -159,7 +159,7 @@ $(function() {
   }
 
   function isSubmitAsOtherUserShowing() {
-      return $('.selectRequestee').length > 0;
+      return $('#selectRequestee').length > 0;
   }
 
   function submissionDataExists() {
@@ -180,7 +180,7 @@ $(function() {
     }
   }
   $('.select-country').selectize();
-  var $select_requestee = $('.selectRequestee').selectize({
+  var $selectRequestee = $('#selectRequestee').selectize({
       valueField: '_id',
       labelField: 'name',
       searchField: ['name'],
@@ -189,28 +189,49 @@ $(function() {
         updateVolunteerName(value);
       }
   });
+  var $selectStaff = $('#selectStaff').selectize({
+      valueField: '_id',
+      labelField: 'name',
+      searchField: ['name'],
+      sortField: 'name'
+  });
 
 
   if (isSubmitAsOtherUserShowing()) {
       $.ajax({
           method: "GET",
-          url: "/api/users?maxAccess=VOLUNTEER",
+          url: "/api/users?maxAccess=0",
           dataType: "json",
           success: function(json) {
             users = json;
             console.log(json);
-            $select_requestee[0].selectize.addOption(json);
-            $select_requestee[0].selectize.refreshOptions(false);
+            $selectRequestee[0].selectize.addOption(json);
+            $selectRequestee[0].selectize.refreshOptions(false);
             if(submissionDataExists()) {
                 // A failure just occurred during submission: we need to replace the previously submitted data
                 if (isSubmitAsOtherUserShowing() && submissionData.userId !== undefined) {
-                    $select_requestee[0].selectize.setValue(submissionData.userId);
+                    $selectRequestee[0].selectize.setValue(submissionData.userId);
                 }
                 updateVolunteerName(submissionData.userId);
             }
           }
       });
   }
+  $.ajax({
+      method: "GET",
+      url: "/api/users?minAccess=1",
+      dataType: "json",
+      success: function(json) {
+        $selectStaff[0].selectize.addOption(json);
+        $selectStaff[0].selectize.refreshOptions(false);
+        if(submissionDataExists()) {
+            // A failure just occurred during submission: we need to replace the previously submitted data
+            if (submissionData.staffId !== undefined) {
+                $selectStaff[0].selectize.setValue(submissionData.staffId);
+            }
+        }
+      }
+  });
 
   // Load the JSON file of the countries
   $.ajax({
@@ -266,8 +287,9 @@ $(function() {
       }
       var userId;
       if (isSubmitAsOtherUserShowing()) {
-          userId = $select_requestee[0].selectize.getValue();
+          userId = $selectRequestee[0].selectize.getValue();
       }
+      var staffId = $selectStaff[0].selectize.getValue();
       var counterpartApproved = $('#approvalCheckbox').is(':checked');
 
       var url = '/api/requests';
@@ -283,6 +305,7 @@ $(function() {
           contentType: "application/x-www-form-urlencoded",
           data: {
               userId: userId,
+              staffId: staffId,
               legs: legs,
               counterpartApproved: counterpartApproved,
           },

--- a/public/scss/submission.scss
+++ b/public/scss/submission.scss
@@ -34,4 +34,8 @@
 		margin: 10px auto;
 	}
 
+	#request-submit {
+		margin-top: 10px;
+	}
+
 }

--- a/routes/helpers.js
+++ b/routes/helpers.js
@@ -12,6 +12,7 @@ var fs = require('fs');
 var twilio = require('twilio');
 var mailgun = require('mailgun-js');
 var mailcomposer = require('mailcomposer');
+var mongoose = require('mongoose');
 var countryFilePath = 'public/data/countryList.json';
 var countryListFile = fs.readFileSync(countryFilePath, 'utf8');
 var countriesDictionary = JSON.parse(countryListFile);
@@ -71,11 +72,16 @@ module.exports.getEndDate = function (request) {
 	}
 };
 
-module.exports.getRequests = function (req, res, pending, cb) {
+module.exports.getRequests = function (req, res, options, cb) {
 	if (req.user) {
-		var matchUser = {};
+		var matchRequest = {};
+		if (options && options._id) {
+			matchRequest._id = mongoose.Types.ObjectId(options._id);
+			console.log('Looking for request with id: ' + matchRequest._id);
+		}
+
 		if (req.user.access < Access.STAFF) {
-			matchUser.userId = req.user._id;
+			matchRequest.userId = req.user._id;
 		}
 
 		var matchCountry = {};
@@ -85,7 +91,7 @@ module.exports.getRequests = function (req, res, pending, cb) {
 
 		Request.aggregate([
 			{
-				$match: matchUser,
+				$match: matchRequest,
 			},
 			{
 				// JOIN with the user data belonging to each request
@@ -102,10 +108,51 @@ module.exports.getRequests = function (req, res, pending, cb) {
 				$unwind: '$user',
 			},
 			{
+				// JOIN with the user data belonging to each request
+				$lookup: {
+					from: 'users',
+					localField: 'staffId',
+					foreignField: '_id',
+					as: 'staff',
+				},
+			},
+			{
+				// Only one staff will ever match (emails are unique)
+				// Convert the staff key to a single document from an array
+				$unwind: '$staff',
+			},
+			{
 				$match: matchCountry,
 			},
 			{
-				$match: (pending !== undefined ? { 'status.isPending': pending } : {}),
+				$match: (options && options.pending !== undefined ?
+						{ 'status.isPending': options.pending } : {}),
+			},
+			{
+				// Hide certain fields of the output (including password hashes)
+				$project: {
+					userId: true,
+					staffId: true,
+					counterpartApproved: true,
+					comments: true,
+					legs: true,
+					timestamp: true,
+					status: true,
+					user: {
+						name: true,
+						email: true,
+						phone: true,
+						access: true,
+						countryCode: true,
+					},
+					staff: {
+						name: true,
+						email: true,
+						phone: true,
+						access: true,
+						countryCode: true,
+					},
+				},
 			},
 		], function (err, requests) {
 			if (err) {
@@ -128,8 +175,22 @@ module.exports.getRequests = function (req, res, pending, cb) {
 module.exports.getUsers = function (options, cb) {
 	var q = (options.user !== undefined ? options.user : {});
 	if (options.maxAccess !== undefined) {
-		q.access = { $lte: options.maxAccess };
+		if (q.access === undefined) {
+			q.access = {};
+		}
+
+		q.access.$lte = options.maxAccess;
 	}
+
+	if (options.minAccess !== undefined) {
+		if (q.access === undefined) {
+			q.access = {};
+		}
+
+		q.access.$gte = options.minAccess;
+	}
+
+	console.log(q);
 
 	// Note: using lean() so that users is a JS obj, instead of a Mongoose obj
 	User.find(q, 'access name email phone _id countryCode').lean().exec(

--- a/routes/helpers.js
+++ b/routes/helpers.js
@@ -74,14 +74,22 @@ module.exports.getEndDate = function (request) {
 
 module.exports.getRequests = function (req, res, options, cb) {
 	if (req.user) {
-		var matchRequest = {};
+		var matchUsers = {};
 		if (options && options._id) {
-			matchRequest._id = mongoose.Types.ObjectId(options._id);
-			console.log('Looking for request with id: ' + matchRequest._id);
+			matchUsers._id = mongoose.Types.ObjectId(options._id);
+			console.log('Looking for request with id: ' + matchUsers._id);
 		}
 
 		if (req.user.access < Access.STAFF) {
-			matchRequest.userId = req.user._id;
+			matchUsers.userId = req.user._id;
+		}
+
+		if (options && options.staffId) {
+			matchUsers.staffId = req.staffId;
+		}
+
+		if (options && options.userId) {
+			matchUsers.userId = req.userId;
 		}
 
 		var matchCountry = {};
@@ -91,7 +99,7 @@ module.exports.getRequests = function (req, res, options, cb) {
 
 		Request.aggregate([
 			{
-				$match: matchRequest,
+				$match: matchUsers,
 			},
 			{
 				// JOIN with the user data belonging to each request

--- a/routes/views.js
+++ b/routes/views.js
@@ -131,6 +131,7 @@ router.renderEditRequest = function (req, res) {
 
 		sub = {
 			userId: req.request.userId,
+			staffId: req.request.staffId,
 			legs: req.request.legs,
 			counterpartApproved: '' + req.request.counterpartApproved,
 		};

--- a/routes/views.js
+++ b/routes/views.js
@@ -221,8 +221,6 @@ router.renderApproval = function (req, res) {
 		links: links,
 		messages: req.flash('approvalFlash'),
 		request: req.request,
-		nextRequestId: req.nextRequestId,
-		prevRequestId: req.prevRequestId,
 	});
 };
 

--- a/views/approval.jade
+++ b/views/approval.jade
@@ -12,21 +12,34 @@ block content
 				include flash
 				
 				#request
-					if user
-						h2 Volunteer Contact 
-						.shadow-box
-							p
-								span 
-									b Name: 
-								span= request.user.name
-							p
-								span 
-									b Email: 
-								span= (request.user.email ? request.user.email : "No email on file.")
-							p
-								span 
-									b Phone: 
-								span= (request.user.phone ? request.user.phone : "No phone on file.")
+					h2 Volunteer 
+					.shadow-box
+						p
+							span 
+								b Name: 
+							span= request.user.name
+						p
+							span 
+								b Email: 
+							span= (request.user.email ? request.user.email : "No email on file.")
+						p
+							span 
+								b Phone: 
+							span= (request.user.phone ? request.user.phone : "No phone on file.")
+					h2 Assigned Staff 
+					.shadow-box
+						p
+							span 
+								b Name: 
+							span= request.staff.name
+						p
+							span 
+								b Email: 
+							span= (request.staff.email ? request.staff.email : "No email on file.")
+						p
+							span 
+								b Phone: 
+							span= (request.staff.phone ? request.staff.phone : "No phone on file.")
 					h2 Trip Itinerary
 					.shadow-box
 						each leg in request.legs

--- a/views/dashboard.jade
+++ b/views/dashboard.jade
@@ -38,20 +38,27 @@ block content
                     a.small(href='#', data-value='limit.onLeave', tabindex='-1')
                       input(type='checkbox')
                       |  On-leave
+                  li
+                    a.small(href='#', data-value='limit.assignedMe', tabindex='-1')
+                      input(type='checkbox')
+                      |  Assigned to me
               input.form-control(type='text', placeholder='Search...')
 
         #dashboardTable
             table.request-table.table.table-striped.table-hover.table-bordered
               thead
                 tr
-                  th(data-priority="0") Name
-                  th(data-priority="1") Start Date
-                  th(data-priority="2") End Date
-                  th(data-priority="3") Countries
+                  th(data-priority="0") Volunteer
+                  th(data-priority="1") Assigned Staff
+                  th(data-priority="2") Start Date
+                  th(data-priority="3") End Date
+                  th(data-priority="4") Countries
                   th(data-priority="10") Approved
               tbody
 
 block scripts
+  script.
+    var currentUser = !{JSON.stringify(user)};
   script(src='/js/moment.js')
   script(src='/js/datatables.js')
   script(src='/js/fastclick.js')

--- a/views/submissionForm.jade
+++ b/views/submissionForm.jade
@@ -19,8 +19,11 @@ block content
         include flash
 
         if shouldSelectRequestee
-          label.info(for='selectRequestee') Select Requestee
-          select.form-control.selectRequestee(placeholder='John Doe')
+          label.info(for='selectRequestee') Select the Volunteer
+          select.form-control#selectRequestee(placeholder='John Doe')
+        
+        label.info(for='selectStaff') Assign a Staff Member
+        select.form-control#selectStaff(placeholder='Patrick Choquette')
 
         #request-submit
 


### PR DESCRIPTION
Finished #58.
- Updated build script to assign random staff member
- Request models now include a staffId
- Submission page includes a selectize input to assign a staff or admin
- /api/users endpoint now accepts a min or max access level
- handleRequestId no longer finds next and previous requests
- Hashes are no longer included when looking up users in requests
- Added automatic comment when changing assigned user
- Added feature to getRequests by _id
- Show assigned staff member on approval page
- Removed reference to previous/next request id
- Hashes are hidden from the user object passed to Jade templates
- Added column with assigned staff to dashboard table
- Added filter to limit to the requests assigned to the logged in user

Updated submission/edit page to assign a staff member:
![image](https://cloud.githubusercontent.com/assets/2907397/14291451/a88e8fc0-fb31-11e5-8bee-c10ec135fcce.png)

Updated approval page with assigned staff member:
![image](https://cloud.githubusercontent.com/assets/2907397/14291433/996d9c3e-fb31-11e5-95ac-06275b1ae766.png)

Updated dashboard page with search filter:
![image](https://cloud.githubusercontent.com/assets/2907397/14291402/788342b2-fb31-11e5-9c81-f8a00405dfe4.png)
