### PR TITLE
Use MongoStore in place of MemoryStore

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,8 +45,23 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(flash());
 
+mongoose.connect(process.env.MONGO_CONNECTION_STRING);
+mongoose.connection.on('error', function (err) {
+	if (err) {
+		console.log(err);
+	}
+});
+
+var MongoStore = require('connect-mongo')(session);
+
+app.use(session({
+	secret: process.env.SESSION_SECRET,
+	store: new MongoStore({
+		mongooseConnection: mongoose.connection,
+	}),
+}));
+
 // required for passport
-app.use(session({ secret: process.env.SESSION_SECRET }));
 app.use(passport.initialize());
 app.use(passport.session()); // persistent login sessions
 app.use(flash()); // use connect-flash for flash messages stored in session
@@ -73,13 +88,6 @@ app.use(function (req, res, next) {
 // 		return next();
 // 	});
 // }
-
-mongoose.connect(process.env.DATABASE_URL);
-mongoose.connection.on('error', function (err) {
-	if (err) {
-		console.log(err);
-	}
-});
 
 // pass passport for configuration
 require(__dirname + '/config/passport.js')(passport);

--- a/build_scripts/buildRequestBase.js
+++ b/build_scripts/buildRequestBase.js
@@ -21,7 +21,7 @@ var Request = require(__dirname + '/../models/request');
 var REQUESTS_TO_GENERATE = 100; // * Math.floor((50 * Math.random()));
 var DRY_RUN = false;
 
-mongoose.connect(process.env.DATABASE_URL);
+mongoose.connect(process.env.MONGO_CONNECTION_STRING);
 mongoose.connection.on('error', function (err) {
 	if (err) {
 		console.log(err);

--- a/build_scripts/buildUserBase.js
+++ b/build_scripts/buildUserBase.js
@@ -5,7 +5,7 @@ require(__dirname + '/../setup');
 
 var mongoose = require('mongoose');
 
-mongoose.connect(process.env.DATABASE_URL);
+mongoose.connect(process.env.MONGO_CONNECTION_STRING);
 mongoose.connection.on('error', function (err) {
 	if (err) {
 		console.log(err);

--- a/config/environment.defaults.js
+++ b/config/environment.defaults.js
@@ -11,7 +11,7 @@
 module.exports = {
 	NODE_ENV: 'development',
 	SESSION_SECRET: 'drtwxroGWs9f93AQWbALN8Q7cvgNe4',
-	DATABASE_URL: 'mongodb://localhost:27017/bonvoyage',
+	MONGO_CONNECTION_STRING: 'mongodb://localhost:27017/bonvoyage',
 
 	// The Google Spreadsheet key where the Peace Corps Leave Requests can be found
 	PC_SPREADSHEET_KEY: '',

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "body-parser": "~1.15.0",
     "cheerio": "^0.20.0",
     "connect-flash": "^0.1.1",
+    "connect-mongo": "^1.1.0",
     "cookie-parser": "~1.4.1",
     "csvtojson": "^0.5.3",
     "dateonly": "^1.1.0",

--- a/routes/api.js
+++ b/routes/api.js
@@ -127,6 +127,16 @@ function validateRequestSubmission(req, res, failureRedirect, cb) {
 
 	var staffId = req.body.staffId;
 
+	if (staffId === undefined || staffId === '') {
+		req.session.submission = req.body;
+		req.flash('submissionFlash', {
+			text: 'You must select a staff member to assign this leave request to.',
+			class: 'danger',
+		});
+		res.end(JSON.stringify({ redirect: failureRedirect }));
+		return cb(null);
+	}
+
 	// Verify that the volunteer exists
 	helpers.getUsers({
 		user: {

--- a/scrapers/storeWarnings.js
+++ b/scrapers/storeWarnings.js
@@ -7,7 +7,7 @@ var mongoose = require('mongoose');
 var uuid = require('node-uuid');
 var Warning = require(__dirname + '/../models/warning');
 
-mongoose.connect(process.env.DATABASE_URL);
+mongoose.connect(process.env.MONGO_CONNECTION_STRING);
 
 function removeAll(newBatchUUID, source) {
 	console.log('Removing all ' + source +


### PR DESCRIPTION
- Passport authentications are now persisted in Mongo, instead of RAM
- Renamed DATABASE_URL as MONGO_CONNECTION_URL
- Fixed error on submitting without assigned staff member
