### PR TITLE
Fix #140

### DIFF
--- a/public/css/approval.css
+++ b/public/css/approval.css
@@ -45,7 +45,12 @@
 #htmlwrapper #submit-comment {
   margin-bottom: 0; }
 
-#htmlwrapper .checkbox.useiconx input[type=radio]:checked + label:after {
+#htmlwrapper .checkbox.useiconpending input[type=radio]:checked + label:after {
+  content: "\f017";
+  font-size: 13px;
+  top: 5px; }
+
+#htmlwrapper .checkbox.useicondenied input[type=radio]:checked + label:after {
   content: "\f00d";
   font-size: 13px;
   top: 5px; }

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -26,7 +26,6 @@ $(function () {
 		},
 		limit: {
 			onLeave: false,
-			archived: false,
 			assignedMe: false,
 		},
 	};
@@ -70,7 +69,7 @@ $(function () {
 					if (data) {
 						return data.name;
 					} else {
-						return 'None (Archived)';
+						return 'None';
 					}
 				},
 			},
@@ -182,9 +181,7 @@ $(function () {
 			) {
 				var rowData = table.rows({order:'original'}).data()[dataIndex];
 				// console.log(rowData.reviewer && rowData.reviewer._id);
-				// console.log(searchOptions.limit.archived);
 				if (
-					(!searchOptions.limit.archived || rowData.reviewer === null) &&
 					(!searchOptions.limit.assignedMe || (rowData.reviewer !== null && currentUser._id == rowData.reviewer._id))
 				) {
 					if (searchOptions.limit.onLeave) {

--- a/public/js/submission.js
+++ b/public/js/submission.js
@@ -4,7 +4,6 @@
 /* globals window */
 /* globals getWarnings */
 /* globals submissionData */
-/* globals signedInUser */
 /* globals PICKADATE_DISPLAY_FORMAT */
 
 $(function() {
@@ -13,7 +12,6 @@ $(function() {
   var addedLegCount = -1; // 0 indexed count (doesn't decrease when legs are removed)
   var arrCountries = [];
   var users = null;
-  var selectedUser = signedInUser.access === 0 ? signedInUser : null;
 
   function insertAtIndex(i, id, data) {
       if(i === 1) {
@@ -213,28 +211,11 @@ $(function() {
       sortField: 'name'
   });
 
-  function updateVolunteerName(volunteer) {
-    if (volunteer) {
-      $('#submissionName').text(' (' + volunteer.name + ') ');
-      if (selectedUser) {
-        $selectReviewer[0].selectize.updateOption(selectedUser._id, volunteer);
-      } else {
-        $selectReviewer[0].selectize.addOption(volunteer);
-      }
-      $selectReviewer[0].selectize.refreshOptions(false);
-    }
-  }
-
   var $selectRequestee = $('#selectRequestee').selectize({
       valueField: '_id',
       labelField: 'name',
       searchField: ['name'],
       sortField: 'name',
-      onChange: function(value) {
-        var volunteer = $selectRequestee[0].selectize.options[value];
-        updateVolunteerName(volunteer);
-        selectedUser = volunteer;
-      }
   });
 
   if (isSubmitAsOtherUserShowing()) {
@@ -250,8 +231,6 @@ $(function() {
                 // A failure just occurred during submission: we need to replace the previously submitted data
                 if (submissionData.volunteer !== undefined) {
                   $selectRequestee[0].selectize.setValue(submissionData.volunteer);
-                  var volunteer = $selectRequestee[0].selectize.options[submissionData.volunteer];
-                  updateVolunteerName(volunteer);
                 }
             }
           }
@@ -263,12 +242,6 @@ $(function() {
       url: "/api/users?minAccess=1&maxAccess=1",
       dataType: "json",
       success: function(json) {
-        // If a user is selected, add them as an option to be a reviewer
-        // Except don't give volunteers the option to assign themselves on the submission page
-        if (selectedUser &&
-          (signedInUser.access !== 0 || window.location.pathname !== '/dashboard/submit')) {
-          json.push(selectedUser);
-        }
         $selectReviewer[0].selectize.addOption(json);
         $selectReviewer[0].selectize.refreshOptions(false);
         if(submissionDataExists()) {

--- a/public/scss/approval.scss
+++ b/public/scss/approval.scss
@@ -55,7 +55,13 @@
 		margin-bottom: 0;
 	}
 
-	.checkbox.useiconx input[type=radio]:checked + label:after {
+	.checkbox.useiconpending input[type=radio]:checked + label:after {
+		content: "\f017";
+		font-size: 13px;
+    top: 5px;
+	}
+
+	.checkbox.useicondenied input[type=radio]:checked + label:after {
 		content: "\f00d";
 		font-size: 13px;
     top: 5px;

--- a/routes/api.js
+++ b/routes/api.js
@@ -569,7 +569,7 @@ router.postApproval = function (req, res) {
 	var newReviewer = approvalFormBody.reviewer === 'none' ? null : approvalFormBody.reviewer;
 	Request.findByIdAndUpdate(id, {
 		$set: {
-			'status.isPending': approvalFormBody.approval === 'PENDING',
+			'status.isPending': newReviewer !== null,
 			'status.isApproved': approvalFormBody.approval === 'APPROVED',
 			reviewer: newReviewer,
 		},

--- a/tests/api.js
+++ b/tests/api.js
@@ -719,7 +719,7 @@ describe('POST /api/requests/:requestId/approval', function () {
 		async.eachSeries(requests, function (request, cb) {
 			agents.admin.request
 			.post('/api/requests/' + request._id + '/approval')
-			.send({ approval: true, comment: '', reviewer: request.reviewer })
+			.send({ approval: 'APPROVED', comment: '', reviewer: request.reviewer })
 			.expect(200)
 				.end(function (err) {
 					if (err) {
@@ -746,7 +746,7 @@ describe('POST /api/requests/:requestId/approval', function () {
 		async.eachSeries(requests, function (request, cb) {
 			agents.admin.request
 				.post('/api/requests/' + request._id + '/approval')
-				.send({ approval: false, comment: '', reviewer: request.reviewer })
+				.send({ approval: 'DENIED', comment: '', reviewer: request.reviewer })
 				.expect(200)
 				.end(function (err) {
 					if (err) {

--- a/views/approval.jade
+++ b/views/approval.jade
@@ -46,7 +46,7 @@ block content
 									b Phone(s): 
 								span.phones= (request.reviewer.phones && request.reviewer.phones.length > 0 ? request.reviewer.phones.join(', ') : "No phone on file.")
 						else
-							p None. To un-archive this request, re-assign a member 
+							p None. Assign a member 
 								a.editLink(href='#') here.
 					h2 Trip Itinerary
 					.shadow-box
@@ -107,39 +107,39 @@ block content
 						textarea.form-control#new-comment(rows=3, onkeyup="commentStoppedTyping()", name="content")
 						button.btn.btn-default.disabled#submit-comment Submit Comment
 					//- Approval Form
-					h2 Approval Form
-					#approval.shadow-box
-						if (request.reviewer && user._id.equals(request.reviewer._id) && user.access >= 1)
+					if (request.reviewer && user._id.equals(request.reviewer._id) && user.access >= 1)
+						h2 Approval Form
+						#approval.shadow-box
 							//- Mark Approval
 							p
 								b Mark as...
+							.checkbox.checkbox-warning.useiconpending
+								input(type="radio", name="approval", id="pendingCheckbox", checked)
+								label(for='pendingCheckbox')
+									p Leave Pending
 							.checkbox.checkbox-success
-								input(type="radio", name="approval", id="approvalCheckbox", checked)
+								input(type="radio", name="approval", id="approvalCheckbox")
 								label(for='approvalCheckbox', id="approvalCheckboxLabel")
 									p Approved
-							.checkbox.checkbox-danger.useiconx
+							.checkbox.checkbox-danger.useicondenied
 								input(type="radio", name="approval", id="denialCheckbox")
 								label(for='denialCheckbox')
 									p Denied
 							//- Re-assign
-							p
-								b Assign a New Reviewer
-							select.form-control#selectReviewer(placeholder='Loading...')
-							p.none-notice 
-								em ** 
-								| Selecting "None" will archive this request.
+							#reviewer
+								p
+									b Assign a New Reviewer
+								select.form-control#selectReviewer(placeholder='Loading...')
 							//- Add Comment
 							p
 								b Add an Explanation
-							textarea.form-control#explanation(rows=3)
+							textarea.form-control#explanation(rows=3, placeholder='Comment (optional)')
 							//- Submit
-							button#request-approval-btn.btn.btn-success(type='button')
-								span.fa.fa-archive
-								|  Approve and Archive
-						else
-							p Only the assigned staff reviewer can approve this request.
+							button#request-approval-btn.btn.btn-warning(type='button')
+								span.fa.fa-paper-plane
+								|  Reassign and Comment
 				// If staff or higher
-				//- if user && user.access > 0 
+				//- if user && user.access > 0
 				//- 	#request_approval.row
 				//- 		.col-xs-6
 				//- 			button(class="btn btn-success" + (request.status.isPending == false && request.status.isApproved ? " disabled" : ""), id="request-approve-btn") Approve
@@ -163,6 +163,8 @@ block content
 block scripts
 	script.
 		var volunteer = !{JSON.stringify(request.volunteer)};
+		var reviewer = !{JSON.stringify(request.reviewer)};
+		//- var currentUser = !{JSON.stringify(user)};
 	script(src='/js/moment.js')
 	script(src='/js/selectize.min.js')
 	script(src='/js/utils.js')

--- a/views/dashboard.jade
+++ b/views/dashboard.jade
@@ -41,10 +41,6 @@ block content
                     a.small(href='#', data-value='limit.onLeave', tabindex='-1')
                       input(type='checkbox')
                       |  On-leave
-                  li
-                    a.small(href='#', data-value='limit.archived', tabindex='-1')
-                      input(type='checkbox')
-                      |  Archived
                   if user.access >= 1
                     li
                       a.small(href='#', data-value='limit.assignedMe', tabindex='-1')


### PR DESCRIPTION
- Add a "Leave Pending" option, which is checked by default
  - If the pending option is checked, then the option to assign "None" will be removed
    - This option will only be available if "Approve" has been selected
- Remove the ability to assign a volunteer as a reviewer
- If "Deny" is checked, then the re-assignment input will be hidden
- The approval form will be hidden from volunteers
- The submit button's text will be updated to remove references to "archiving"
  - The dashboard will also be updated to no longer use the term "archive"
- Updated tests for the approval form
